### PR TITLE
feat: implement float/1 type test built-in predicate

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -33,7 +33,7 @@
 - ✅ `atom/1` – Test for atom
 - ✅ `number/1` – Test for number (integer or float)
 - ✅ `integer/1` – Test for integer
-- ❌ `float/1` – Test for float
+- ✅ `float/1` – Test for float
 - ❌ `atomic/1` – Test for atomic term (atom or number)
 - ✅ `compound/1` – Test for compound term
 - ❌ `callable/1` – Test for callable term

--- a/prolog/engine.py
+++ b/prolog/engine.py
@@ -266,6 +266,13 @@ class PrologEngine:
                 return iter([result])
             return iter([])
 
+        # float/1 - Type check for float
+        if functor == "float" and len(args) == 1:
+            result = self._builtin_float(args[0], subst)
+            if result is not None:
+                return iter([result])
+            return iter([])
+
         # functor/3 - Extract/construct functor
         if functor == "functor" and len(args) == 3:
             return self._builtin_functor(args[0], args[1], args[2], subst)
@@ -952,6 +959,13 @@ class PrologEngine:
         """Built-in integer/1 predicate - succeeds if term is an integer."""
         term = deref(term, subst)
         if isinstance(term, Number) and isinstance(term.value, int):
+            return subst
+        return None
+
+    def _builtin_float(self, term: any, subst: Substitution) -> Substitution | None:
+        """Built-in float/1 predicate - succeeds if term is a float."""
+        term = deref(term, subst)
+        if isinstance(term, Number) and isinstance(term.value, float):
             return subst
         return None
 

--- a/tests/test_iso_core.py
+++ b/tests/test_iso_core.py
@@ -193,6 +193,30 @@ class TestISONumber:
         assert not prolog.has_solution("number(f(1))")
 
 
+class TestISOFloat:
+    """ISO 8.3.3 - Type testing: float/1
+
+    Conformity mapping: N/A - float/1 predicate not tested in iso-conformity-tests.pl
+    """
+
+    def test_float_floats(self):
+        # Conformity: N/A
+        prolog = PrologInterpreter()
+        assert prolog.has_solution("float(1.5)")
+        assert prolog.has_solution("float(3.14159)")
+        assert prolog.has_solution("float(-2.5)")
+        assert prolog.has_solution("float(0.0)")
+
+    def test_float_non_floats(self):
+        # Conformity: N/A
+        prolog = PrologInterpreter()
+        assert not prolog.has_solution("float(X)")
+        assert not prolog.has_solution("float(a)")
+        assert not prolog.has_solution("float(1)")
+        assert not prolog.has_solution("float(f(1.5))")
+        assert not prolog.has_solution("float([1.5])")
+
+
 class TestISOFunctor:
     """ISO 8.5.1 - Term comparison: functor/3
 


### PR DESCRIPTION
- Add float/1 builtin that succeeds for floating-point numbers
- Add comprehensive tests covering success and failure cases
- Update FEATURES.md to mark float/1 as implemented