### PR TITLE
feat: implement asserta/1 and assertz/1 builtins

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -60,8 +60,9 @@
 - ✅ `setof/3` – Collect unique sorted solutions
 
 ### Database Modification (ISO 8.9)
-- ❌ `asserta/1` – Add clause at beginning
-- ❌ `assertz/1` – Add clause at end (assert/1 adds at end)
+- ✅ `asserta/1` – Add clause at beginning
+- ✅ `assertz/1` – Add clause at end
+- ✅ `assert/1` – Add clause at end (equivalent to assertz/1)
 - ✅ `retract/1` – Remove clause
 - ❌ `abolish/1` – Remove all clauses for predicate
 - ✅ `clause/2` – Retrieve clause definition
@@ -172,9 +173,8 @@
 4. **Operator Definition**: `op/3` for custom operators
 
 ### Significant Deviations
-1. **Assert Ordering**: `assert/1` adds at end, not beginning like `assertz/1`
-2. **Exception Handling**: Simplified `catch/3` without full ISO exception types
-3. **Character Code Syntax**: Some advanced character code forms not supported
+1. **Exception Handling**: Simplified `catch/3` without full ISO exception types
+2. **Character Code Syntax**: Some advanced character code forms not supported
 
 ### Parser Limitations
 1. **Hex Character Codes**: `0'\xHH\` syntax not fully supported

--- a/prolog/engine.py
+++ b/prolog/engine.py
@@ -340,9 +340,23 @@ class PrologEngine:
                 return iter([result])
             return iter([])
 
-        # assert/1 - Add clause to database
+        # asserta/1 - Add clause at beginning
+        if functor == "asserta" and len(args) == 1:
+            result = self._builtin_assert(args[0], subst, position="front")
+            if result is not None:
+                return iter([result])
+            return iter([])
+
+        # assertz/1 - Add clause at end
+        if functor == "assertz" and len(args) == 1:
+            result = self._builtin_assert(args[0], subst, position="back")
+            if result is not None:
+                return iter([result])
+            return iter([])
+
+        # assert/1 - Add clause to database (equivalent to assertz/1)
         if functor == "assert" and len(args) == 1:
-            result = self._builtin_assert(args[0], subst)
+            result = self._builtin_assert(args[0], subst, position="back")
             if result is not None:
                 return iter([result])
             return iter([])
@@ -1248,8 +1262,8 @@ class PrologEngine:
         result_list = List(tuple(sorted_solutions), None)
         return unify(result, result_list, subst)
 
-    def _builtin_assert(self, clause_term: any, subst: Substitution) -> Substitution | None:
-        """Built-in assert/1 predicate - Add a clause to the database."""
+    def _builtin_assert(self, clause_term: any, subst: Substitution, position: str = "back") -> Substitution | None:
+        """Built-in assert predicates - Add a clause to the database."""
         clause_term = deref(clause_term, subst)
         clause_term = apply_substitution(clause_term, subst)
 
@@ -1265,8 +1279,11 @@ class PrologEngine:
             # It's a fact
             new_clause = Clause(clause_term, None)
 
-        # Add to the clause database
-        self.clauses.append(new_clause)
+        # Add to the clause database at the specified position
+        if position == "front":
+            self.clauses.insert(0, new_clause)
+        else:
+            self.clauses.append(new_clause)
 
         return subst
 
@@ -1586,7 +1603,7 @@ class PrologEngine:
             "atom", "number", "var", "nonvar",
             "functor", "arg",
             "findall", "bagof", "setof",
-            "assert", "retract",
+            "assert", "asserta", "assertz", "retract",
             "maplist",
             "predicate_property", "catch"
         }

--- a/tests/test_asserts.py
+++ b/tests/test_asserts.py
@@ -1,0 +1,155 @@
+"""Tests for asserta/1, assertz/1, and assert/1 builtins."""
+
+import pytest
+from prolog import PrologInterpreter
+
+
+class TestAsserta:
+    """Tests for asserta/1 predicate."""
+
+    def test_asserta_fact_ordering(self):
+        """Test that asserta/1 adds facts at the beginning."""
+        prolog = PrologInterpreter()
+        # Add initial facts
+        prolog.query_once("assert(p(1)).")
+        prolog.query_once("assert(p(2)).")
+
+        # Add fact with asserta (should go to front)
+        prolog.query_once("asserta(p(0)).")
+
+        # Query should find p(0) first
+        results = list(prolog.query("p(X)."))
+        assert len(results) == 3
+        assert results[0]['X'] == 0  # asserta fact first
+        assert results[1]['X'] == 1  # original first fact
+        assert results[2]['X'] == 2  # original second fact
+
+    def test_asserta_multiple(self):
+        """Test multiple asserta calls."""
+        prolog = PrologInterpreter()
+        prolog.query_once("assert(p(1)).")
+        prolog.query_once("asserta(p(0)).")
+        prolog.query_once("asserta(p(-1)).")
+
+        results = list(prolog.query("p(X)."))
+        assert len(results) == 3
+        assert results[0]['X'] == -1  # Last asserta first
+        assert results[1]['X'] == 0   # First asserta second
+        assert results[2]['X'] == 1   # Original last
+
+
+class TestAssertz:
+    """Tests for assertz/1 predicate."""
+
+    def test_assertz_fact_ordering(self):
+        """Test that assertz/1 adds facts at the end."""
+        prolog = PrologInterpreter()
+        # Add initial facts
+        prolog.query_once("assert(p(1)).")
+        prolog.query_once("assert(p(2)).")
+
+        # Add fact with assertz (should go to end)
+        prolog.query_once("assertz(p(3)).")
+
+        # Query should find original facts first, then assertz fact
+        results = list(prolog.query("p(X)."))
+        assert len(results) == 3
+        assert results[0]['X'] == 1  # original first
+        assert results[1]['X'] == 2  # original second
+        assert results[2]['X'] == 3  # assertz fact last
+
+    def test_assertz_multiple(self):
+        """Test multiple assertz calls."""
+        prolog = PrologInterpreter()
+        prolog.query_once("assert(p(1)).")
+        prolog.query_once("assertz(p(2)).")
+        prolog.query_once("assertz(p(3)).")
+
+        results = list(prolog.query("p(X)."))
+        assert len(results) == 3
+        assert results[0]['X'] == 1
+        assert results[1]['X'] == 2
+        assert results[2]['X'] == 3
+
+
+class TestAssert:
+    """Tests for assert/1 predicate (should behave like assertz/1)."""
+
+    def test_assert_fact_ordering(self):
+        """Test that assert/1 adds facts at the end (like assertz/1)."""
+        prolog = PrologInterpreter()
+        # Add initial facts
+        prolog.query_once("assert(p(1)).")
+        prolog.query_once("assert(p(2)).")
+
+        # Add fact with assert (should go to end)
+        prolog.query_once("assert(p(3)).")
+
+        # Query should find original facts first, then assert fact
+        results = list(prolog.query("p(X)."))
+        assert len(results) == 3
+        assert results[0]['X'] == 1
+        assert results[1]['X'] == 2
+        assert results[2]['X'] == 3  # assert fact last
+
+
+class TestMixedAssert:
+    """Tests mixing asserta/1, assertz/1, and assert/1."""
+
+    def test_mixed_ordering(self):
+        """Test ordering when mixing different assert variants."""
+        prolog = PrologInterpreter()
+
+        # Add initial fact
+        prolog.query_once("assert(p(2)).")
+
+        # Add with asserta (front)
+        prolog.query_once("asserta(p(1)).")
+
+        # Add with assertz (end)
+        prolog.query_once("assertz(p(4)).")
+
+        # Add with assert (end, like assertz)
+        prolog.query_once("assert(p(5)).")
+
+        # Add another asserta (front)
+        prolog.query_once("asserta(p(0)).")
+
+        results = list(prolog.query("p(X)."))
+        assert len(results) == 5
+        assert results[0]['X'] == 0  # Last asserta
+        assert results[1]['X'] == 1  # First asserta
+        assert results[2]['X'] == 2  # Original
+        assert results[3]['X'] == 4  # assertz
+        assert results[4]['X'] == 5  # assert (like assertz)
+
+
+class TestAssertBuiltins:
+    """Tests for assert builtin properties."""
+
+    def test_asserta_builtin_property(self):
+        """Test that asserta is recognized as a built-in predicate."""
+        prolog = PrologInterpreter()
+        result = prolog.query_once("predicate_property(asserta(_), built_in).")
+        assert result == {}
+
+    def test_assertz_builtin_property(self):
+        """Test that assertz is recognized as a built-in predicate."""
+        prolog = PrologInterpreter()
+        result = prolog.query_once("predicate_property(assertz(_), built_in).")
+        assert result == {}
+
+    def test_assert_deterministic(self):
+        """Test that assert builtins are deterministic (single solution)."""
+        prolog = PrologInterpreter()
+        results = list(prolog.query("assert(p(test))."))
+        assert len(results) == 1
+        assert results[0] == {}
+
+        results = list(prolog.query("asserta(p(test))."))
+        assert len(results) == 1
+        assert results[0] == {}
+
+        results = list(prolog.query("assertz(p(test))."))
+        assert len(results) == 1
+        assert results[0] == {}


### PR DESCRIPTION
Closes #26

- Implement asserta/1 (insert at front) and assertz/1 (append at end)
- Make assert/1 equivalent to assertz/1 for append behavior
- Update _builtin_assert to respect positional ordering when inserting
- Mark as implemented in FEATURES.md and remove the deviation
- Add comprehensive tests for ordering, mixed usage, and builtin properties
- Add asserta/1 and assertz/1 to the BUILTIN_PREDICATES set