### PR TITLE
Fix invalid escape sequence warnings (#38)

### DIFF
--- a/prolog/engine.py
+++ b/prolog/engine.py
@@ -138,14 +138,14 @@ class PrologEngine:
             return iter([])
 
         # Arithmetic comparisons
-        if functor in ["=:=", "=\=", "<", ">", "=<", ">="] and len(args) == 2:
+        if functor in ["=:=", r"=\=", "<", ">", "=<", ">="] and len(args) == 2:
             result = self._builtin_arithmetic_compare(functor, args[0], args[1], subst)
             if result is not None:
                 return iter([result])
             return iter([])
 
         # Term comparisons
-        if functor in ["==", "\\==", "@<", "@=<", "@>", "@>="] and len(args) == 2:
+        if functor in ["==", r"\==", "@<", "@=<", "@>", "@>="] and len(args) == 2:
             result = self._builtin_term_compare(functor, args[0], args[1], subst)
             if result is not None:
                 return iter([result])
@@ -440,7 +440,7 @@ class PrologEngine:
 
         if op == "=:=" and left_val == right_val:
             return subst
-        elif op == "=\=" and left_val != right_val:
+        elif op == r"=\=" and left_val != right_val:
             return subst
         elif op == "<" and left_val < right_val:
             return subst
@@ -1644,7 +1644,7 @@ class PrologEngine:
 
         # List of all built-in functors
         builtins = {
-            "=", "\\=", "\\+", "is", "=:=", "=\=", "<", ">", "=<", ">=", "==", "\\==", "@<", "@=<", "@>", "@>=", "=..",
+            "=", r"\=", r"\+", "is", "=:=", r"=\=", "<", ">", "=<", ">=", "==", r"\==", "@<", "@=<", "@>", "@>=", "=..",
             "member", "append", "length", "reverse", "sort",
             "clause", "call", "once", "true", "fail", "!",
             "write", "writeln", "nl", "format",
@@ -1683,9 +1683,9 @@ class PrologEngine:
             # Control constructs
             ("true", 0), ("fail", 0), ("!", 0), ("nl", 0),
             # Unification and comparison
-            ("=", 2), ("\\=", 2), ("==", 2), ("\\==", 2), ("@<", 2), ("@=<", 2), ("@>", 2), ("@>=", 2),
+            ("=", 2), (r"\=", 2), ("==", 2), (r"\==", 2), ("@<", 2), ("@=<", 2), ("@>", 2), ("@>=", 2),
             # Arithmetic
-            ("is", 2), ("=:=", 2), ("=\=", 2), ("<", 2), (">", 2), ("=<", 2), (">=", 2),
+            ("is", 2), ("=:=", 2), (r"=\=", 2), ("<", 2), (">", 2), ("=<", 2), (">=", 2),
             # Type testing
             ("var", 1), ("nonvar", 1), ("atom", 1), ("number", 1), ("integer", 1), ("float", 1),
             ("atomic", 1), ("compound", 1), ("callable", 1), ("ground", 1),

--- a/tests/test_arithmetic.py
+++ b/tests/test_arithmetic.py
@@ -202,10 +202,10 @@ class TestArithmeticComparisons:
     def test_not_equal(self):
         prolog = PrologInterpreter()
 
-        assert prolog.has_solution("5 =\= 3")
-        assert prolog.has_solution("2 + 3 =\= 6")
-        assert not prolog.has_solution("5 =\= 5")
-        assert not prolog.has_solution("10 - 5 =\= 5")
+        assert prolog.has_solution(r"5 =\= 3")
+        assert prolog.has_solution(r"2 + 3 =\= 6")
+        assert not prolog.has_solution(r"5 =\= 5")
+        assert not prolog.has_solution(r"10 - 5 =\= 5")
 
 
 class TestArithmeticInRules:

--- a/tests/test_meta_interpreter.py
+++ b/tests/test_meta_interpreter.py
@@ -166,9 +166,9 @@ class TestPredicateProperty:
         assert result == {}
 
     def test_builtin_arithmetic_inequality(self):
-        """Test that =\=/2 is recognized as built-in."""
+        r"""Test that =\=/2 is recognized as built-in."""
         prolog = PrologInterpreter()
-        result = prolog.query_once("predicate_property((_ =\= _), built_in).")
+        result = prolog.query_once(r"predicate_property((_ =\= _), built_in).")
         assert result == {}
 
     def test_non_builtin(self):

--- a/tests/test_unification.py
+++ b/tests/test_unification.py
@@ -312,7 +312,7 @@ class TestComplexUnificationPatterns:
 
 
 class TestTermComparison:
-    """Term comparison operators: ==, \==, @<, @=<, @>, @>="""
+    r"""Term comparison operators: ==, \==, @<, @=<, @>, @>="""
 
     def test_term_identity_equal(self):
         """Test ==/2 - term identity (structural equality)"""
@@ -342,7 +342,7 @@ class TestTermComparison:
         assert prolog.has_solution("X == X")
 
     def test_term_identity_not_equal(self):
-        """Test \==/2 - term non-identity"""
+        r"""Test \==/2 - term non-identity"""
         prolog = PrologInterpreter()
 
         # Atoms


### PR DESCRIPTION
## Summary
- use raw string literals for Prolog operators containing backslashes to avoid invalid escape warnings
- update test strings/docstrings to raw strings for arithmetic and comparison operators
- keep built-in predicate listings consistent with corrected operator literals

## Testing
- uv run pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920388bc068832584522c41e4299735)