### PR TITLE
Handle free-variable grouping in bagof/setof

### DIFF
--- a/tests/test_additional_builtins.py
+++ b/tests/test_additional_builtins.py
@@ -260,6 +260,19 @@ class TestSolutionCollection:
         assert result is not None
         assert result['L'] == [1, 2, 3]
 
+    def test_bagof_respects_free_var_order(self):
+        """Bagof should group free variables in goal order, not sorted order."""
+        prolog = PrologInterpreter()
+        results = list(
+            prolog.query(
+                "bagof(0, (member(B, [b1, b2]), member(A, [a1, a2])), L)."
+            )
+        )
+
+        bindings = [(res['B'], res['A']) for res in results]
+        assert bindings == [('b1', 'a1'), ('b1', 'a2'), ('b2', 'a1'), ('b2', 'a2')]
+        assert all(res['L'] == [0] for res in results)
+
     def test_bagof_no_solutions_fails(self):
         """Test bagof/3 fails when no solutions."""
         prolog = PrologInterpreter()


### PR DESCRIPTION
Closes #40 

## Summary
- update bagof/3 and setof/3 to group solutions by free-variable bindings and honor existential quantifiers
- return multiple result sets via iterators so callers receive one solution per free-variable combination
- share grouping helpers for bagof/setof to deduplicate, sort, and bind free variables consistently

## Testing
- uv run pytest tests/test_additional_builtins.py -k "bagof or setof"
- uv run pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69203c4b0738832581ce578eda7817bc)