### PR TITLE
Fix list conversion, ordering, and streaming control flow

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -157,6 +157,7 @@
 - ✅ If-then/else evaluates conditions lazily (only first success) to preserve backtracking
 - ✅ Term comparison uses Prolog ordering (variables < numbers < atoms < compounds/lists) for deterministic sort/setof results
 - ✅ List conversions honor active substitutions when traversing open list tails (e.g., append/sort/reverse)
+- ✅ Python conversions reject improper or partially instantiated lists instead of silently truncating
 
 ## Data Types
 - ✅ Atoms

--- a/tests/test_engine_regressions.py
+++ b/tests/test_engine_regressions.py
@@ -17,6 +17,25 @@ class TestListConversion:
         assert result["R"] == [1, 2, 3]
         assert result["T"] == [2]
 
+    def test_append_open_tail_bindings_not_truncated(self):
+        """Open tails must be bound, not silently dropped during conversion."""
+
+        prolog = PrologInterpreter()
+
+        result = prolog.query_once("append([1|Tail], [2], [1,2]).")
+
+        assert result is not None
+        assert result["Tail"] == []
+
+    def test_append_improper_list_fails(self):
+        """Improper lists should cause append to fail rather than truncate."""
+
+        prolog = PrologInterpreter()
+
+        result = prolog.query_once("append([1|3], [], R).")
+
+        assert result is None
+
 
 class TestMaplistStreaming:
     """maplist should stream predicate solutions."""


### PR DESCRIPTION
## Summary
- honor active substitutions when converting Prolog lists, improving append/sort/reverse behavior with open tails
- ensure maplist, if-then, and if-then-else stream solutions instead of materializing them
- align term comparison ordering with Prolog rules for deterministic sort/setof results and add regression tests/documentation updates

## Testing
- uv run pytest tests/test_engine_regressions.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69205dcd85e48325b76fc7061c84f1c5)