### PR TITLE
Remove unused list_to_compound function

### DIFF
--- a/prolog/utils/__init__.py
+++ b/prolog/utils/__init__.py
@@ -7,7 +7,7 @@ from prolog.utils.list_utils import (
     match_list_to_length,
     python_to_list,
 )
-from prolog.utils.term_utils import list_to_compound, term_sort_key, term_to_string, terms_equal
+from prolog.utils.term_utils import term_sort_key, term_to_string, terms_equal
 from prolog.utils.variable_utils import (
     collect_vars,
     collect_vars_in_order,
@@ -21,7 +21,6 @@ __all__ = [
     "list_to_python",
     "match_list_to_length",
     "python_to_list",
-    "list_to_compound",
     "term_sort_key",
     "term_to_string",
     "terms_equal",

--- a/prolog/utils/term_utils.py
+++ b/prolog/utils/term_utils.py
@@ -61,16 +61,6 @@ def terms_equal(term1: Any, term2: Any) -> bool:
     return False
 
 
-def list_to_compound(lst: List, subst: Substitution) -> Any:
-    """Convert a List structure into nested '.' compounds for ordering."""
-    tail_term = deref(lst.tail, subst) if lst.tail is not None else Atom("[]")
-
-    for elem in reversed(lst.elements):
-        tail_term = Compound(".", (elem, tail_term))
-
-    return tail_term
-
-
 def term_sort_key(term: Any, subst: Substitution | None = None) -> tuple:
     """Generate a deterministic sort key for a term."""
     subst = subst or Substitution()


### PR DESCRIPTION
Closes #65

Remove the unused list_to_compound function from the codebase. It is not referenced anywhere, and keeping it around adds unnecessary maintenance burden.

What changed:
- Deleted the list_to_compound function and its references/imports

Impact:
- No user-facing changes; public API is unaffected

Tests:
- Run test suite to confirm no regressions

Notes:
- If future work requires this functionality, it can be re-added with proper tests.