### PR TITLE
Implement Claude tool for addressing PR comments

### DIFF
--- a/ai-tools/autocoder_utils/cli.py
+++ b/ai-tools/autocoder_utils/cli.py
@@ -4,7 +4,10 @@ import sys
 from pathlib import Path
 from typing import Sequence
 
-from .address_pr_comments import address_pr_comments_with_kilocode as _address_pr_comments_with_kilocode
+from .address_pr_comments import (
+    address_pr_comments_with_claude as _address_pr_comments_with_claude,
+    address_pr_comments_with_kilocode as _address_pr_comments_with_kilocode,
+)
 from .change_tracker import generate_changelog as _generate_changelog
 from .gh_pr_helper import gh_pr_helper as _gh_pr_helper
 from .issue_workflow import IssueWorkflowConfig, run_issue_workflow
@@ -49,6 +52,11 @@ def fix_issue_with_claude(argv: Sequence[str] | None = None) -> None:
 def address_pr_comments_with_kilocode(argv: Sequence[str] | None = None) -> None:
     """CLI wrapper for addressing PR comments using Kilocode."""
     _address_pr_comments_with_kilocode(_argv(argv))
+
+
+def address_pr_comments_with_claude(argv: Sequence[str] | None = None) -> None:
+    """CLI wrapper for addressing PR comments using Claude Code."""
+    _address_pr_comments_with_claude(_argv(argv))
 
 
 def generate_changelog(argv: Sequence[str] | None = None) -> None:

--- a/ai-tools/claude/address-pr-comments-with-claude
+++ b/ai-tools/claude/address-pr-comments-with-claude
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S uv run --script
+#
+# /// script
+# requires-python = ">=3.12"
+# ///
+from autocoder_utils.cli import address_pr_comments_with_claude
+
+
+if __name__ == "__main__":
+    address_pr_comments_with_claude()

--- a/ai-tools/pyproject.toml
+++ b/ai-tools/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = []
 [project.scripts]
 fix-issue-with-kilocode = "autocoder_utils.cli:fix_issue_with_kilocode"
 address-pr-comments-with-kilocode = "autocoder_utils.cli:address_pr_comments_with_kilocode"
+address-pr-comments-with-claude = "autocoder_utils.cli:address_pr_comments_with_claude"
 fix-issue-with-claude = "autocoder_utils.cli:fix_issue_with_claude"
 generate-changelog = "autocoder_utils.cli:generate_changelog"
 gh-pr-helper = "autocoder_utils.cli:gh_pr_helper"

--- a/ai-tools/uv.lock
+++ b/ai-tools/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "ai-workflow-tools"
+version = "0.1.0"
+source = { editable = "." }


### PR DESCRIPTION
Implements a new tool that addresses PR review comments using Claude Code in headless mode, following the same pattern as the issue workflow tools.

Key features:
- Refactored address_pr_comments.py to extract common workflow logic
- Created PRCommentWorkflowConfig class for consistent configuration
- Added session management with timeout support
- Supports JSON output and session ID tracking for resumable sessions
- Fixed PEP8 violation: moved import re to top of file

The implementation minimizes code duplication by:
- Creating run_pr_comment_workflow() as a common entry point
- Making tool execution configurable via PRCommentWorkflowConfig
- Sharing session management code between issue and PR workflows

Both address-pr-comments-with-kilocode and the new address-pr-comments-with-claude use the same underlying workflow with different tool configurations.