### PR TITLE
Fix negation parsing and exponent associativity

### DIFF
--- a/vibeprolog/operator_defaults.py
+++ b/vibeprolog/operator_defaults.py
@@ -38,11 +38,10 @@ DEFAULT_OPERATORS: list[tuple[int, str, str]] = [
     (400, "yfx", "div"),
     (400, "yfx", "<<"),
     (400, "yfx", ">>"),
-    (200, "xfx", "**"),
+    (200, "xfy", "**"),
     (200, "xfy", "^"),
     (200, "fy", "+"),
     (200, "fy", "-"),
-    (200, "fy", "\\"),
 ]
 
 __all__ = ["DEFAULT_OPERATORS"]

--- a/vibeprolog/parser.py
+++ b/vibeprolog/parser.py
@@ -1004,8 +1004,10 @@ VALID_OPERATOR_SPECS = {"xfx", "xfy", "yfx", "yfy", "fx", "fy", "xf", "yf"}
 
 
 def _format_operator_literals(ops: Iterable[str]) -> str:
+    # Sort longest operators first so sequences like "\\+" take precedence over
+    # shorter prefixes such as "\\".
     formatted: list[str] = []
-    for op in sorted(set(ops)):
+    for op in sorted(set(ops), key=lambda value: (-len(value), value)):
         if re.match(r"^[A-Za-z0-9_]+$", op):
             formatted.append(f"/(?<![A-Za-z0-9_]){re.escape(op)}(?![A-Za-z0-9_])/")
         else:


### PR DESCRIPTION
## Summary
- prioritize longer operator tokens to ensure symbols like `\+` are parsed correctly and remove an unnecessary unary `\` operator
- make the `**` operator right-associative to accept chained exponent expressions

## Testing
- uv run pytest --ignore=tests/performance


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ec3bf8b5c8325b0a9337c71a20126)