### PR TITLE
feat: ISO escape sequence parsing for strings and atoms with tests and docs

### DIFF
--- a/docs/CONFORMITY_TESTING.md
+++ b/docs/CONFORMITY_TESTING.md
@@ -1,19 +1,19 @@
 # ISO Prolog Conformity Testing Results
 
-> **Last Updated**: 2025-12-07 22:45:14
+> **Last Updated**: 2025-12-08 20:54:28
 > **Test Suite**: ISO/IEC JTC1 SC22 WG17
 > **Source**: https://www.complang.tuwien.ac.at/ulrich/iso-prolog/conformity_testing
 > **Total Tests**: 40
 
 ## Summary
 
-- **Conforming (PASS)**: 22 (55.0%)
-- **Non-conforming (FAIL)**: 18 (45.0%)
+- **Conforming (PASS)**: 23 (57.5%)
+- **Non-conforming (FAIL)**: 17 (42.5%)
 
 ### Result Distribution
 
-- **OK Results**: 26 (65.0%)
-- **Syntax Errors**: 13 (32.5%)
+- **OK Results**: 29 (72.5%)
+- **Syntax Errors**: 10 (25.0%)
 - **Type Errors**: 0 (0.0%)
 - **Other Errors**: 1 (2.5%)
 
@@ -21,7 +21,7 @@
 
 ### Character Escapes (Tests 1-37)
 
-- Conforming: 19/37 (51.4%)
+- Conforming: 20/37 (54.1%)
 
 ### Operators (Tests 38-40)
 
@@ -56,17 +56,17 @@
 | 23 | `writeq('\0\').` | SYNTAX_ERROR | SYNTAX_ERROR | PASS | OK | OK | error(syntax_error(Unterminated quote... |
 | 24 | `char_code('\e',C).` | SYNTAX_ERROR | OK | FAIL | WAITS | OK |  |
 | 25 | `char_code('\d',C).` | SYNTAX_ERROR | OK | FAIL | OK | OK |  |
-| 26 | `writeq('\u1').` | SYNTAX_ERROR | SYNTAX_ERROR | PASS | WAITS | OK | error(syntax_error(Error trying to pr... |
+| 26 | `writeq('\u1').` | SYNTAX_ERROR | SYNTAX_ERROR | PASS | WAITS | OK | error(syntax_error(Unterminated quote... |
 | 27 | `writeq('\u0021').` | OK | OK | PASS | OK | OK |  |
-| 28 | `put_code(0'\u0021).` | OK | SYNTAX_ERROR | FAIL | OK | OK | error(syntax_error(Unexpected end-of-... |
+| 28 | `put_code(0'\u0021).` | OK | OK | PASS | OK | OK |  |
 | 29 | `writeq("\u0021").` | SYNTAX_ERROR | OK | FAIL | OK | OK |  |
-| 30 | `writeq('\x21\').` | SYNTAX_ERROR | SYNTAX_ERROR | PASS | OK | OK | error(syntax_error(Unterminated quote... |
-| 31 | `writeq('\x0021\').` | OK | SYNTAX_ERROR | FAIL | OK | OK | error(syntax_error(Unterminated quote... |
-| 32 | `X = 0'\u1.` | SYNTAX_ERROR | SYNTAX_ERROR | PASS | OK | OK | error(syntax_error(Unexpected end-of-... |
+| 30 | `writeq('\x21\').` | SYNTAX_ERROR | OK | FAIL | OK | OK |  |
+| 31 | `writeq('\x0021\').` | OK | OK | PASS | OK | OK |  |
+| 32 | `X = 0'\u1.` | SYNTAX_ERROR | SYNTAX_ERROR | PASS | OK | OK | error(syntax_error(No terminal matche... |
 | 33 | `writeq('\n').` | SYNTAX_ERROR | OK | FAIL | OK | OK |  |
 | 34 | `writeq(.).` | SYNTAX_ERROR | OK | FAIL | OK | OK |  |
 | 35 | `'\n''.` | OK | SYNTAX_ERROR | FAIL | OK | OK | error(syntax_error(Unterminated quote... |
-| 36 | `X = 0'\. .` | OK | SYNTAX_ERROR | FAIL | OK | OK | error(syntax_error(Unexpected end-of-... |
+| 36 | `X = 0'\. .` | OK | SYNTAX_ERROR | FAIL | OK | OK | error(syntax_error(No terminal matche... |
 | 37 | `writeq((-)-(-)).` | OK | OK | PASS | OK | OK |  |
 | 38 | `writeq(((:-):-(:-))).` | OK | OK | PASS | OK | OK |  |
 | 39 | `writeq((\\*)=(\\*)).` | OK | OK | PASS | OK | OK |  |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -20,10 +20,10 @@ Status legend:
 | Numbers (int, float, scientific) | ✅      | Includes Edinburgh `<radix>'<number>` syntax (`16'ff`, `2'1010`, `36'ZZZ`) for bases 2-36; `0x`/`0X` prefix accepts case-insensitive hex digits (`0xFF`, `0xff`, `0xAbC`, `0X1a`); underscore digit grouping (`1_000_000`, `3.1415_9265`, `1_0.0e-5`) |
 | Lists (proper, improper)         | ✅      |                                           |
 | Compound terms                   | ✅      |                                           |
-| Strings (quoted)                 | ✅      | Consistent representation with full ISO escape sequence support (\a \b \c \d \e \f \n \r \s \t \v \0...\777 \x... \uXXXX \' \" \\) |
+| Strings (quoted)                 | ✅      | ISO escapes (\a \b \c \d \e \f \n \r \s \t \v \0...\777 \x... \\x...\\ \uXXXX \' \" \\) with backslash-newline continuation and \c suppressed in quoted text |
 | `%` line comments                | ✅      |                                           |
 | `/* … */` block comments         | ✅      | Treated as whitespace; nested supported; `/**` starts PlDoc comments; `/*` after graphic char is part of operator (e.g., `//*`) |
-| Character code syntax (`0'X`)    | ✅      | ISO-compliant - rejects empty literals    |
+| Character code syntax (`0'X`)    | ✅      | ISO-compliant escapes (\x...\\, \uXXXX, octal, named), rejects \c and trailing characters, rejects empty literals |
 | Built-in operator syntax         | ✅      |                                           |
 | `:- op/3` declaration            | ✅      | Full support - defines operators dynamically |
 | Directive prefix operator `:-` (1200, fx) | ✅ | **ISO-required** - Prefix form for directives |

--- a/docs/SYNTAX_NOTES.md
+++ b/docs/SYNTAX_NOTES.md
@@ -63,11 +63,14 @@ Vibe-Prolog supports the Edinburgh `<radix>'<number>` notation for bases 2-36:
 |--------|---------|-------|--------|-------|
 | Basic | `0'a`, `0'Z` | 97, 90 | ✅ Supported | Single character |
 | Escape sequences | `0'\n`, `0'\t`, `0'\r` | 10, 9, 13 | ✅ Supported | Standard escapes |
-| Hex escape | `0'\x41` | 65 | ✅ Supported | No terminator needed |
+| Hex escape | `0'\\x41`, `0'\\x41\\` | 65 | ✅ Supported | Optional trailing backslash terminator |
+| Unicode escape | `0'\\u0041` | 65 | ✅ Supported | Exactly 4 hex digits |
 | Backslash | `0'\\` | 92 | ✅ Supported | Escaped backslash |
 | Single quote | `0'\'` | 39 | ✅ Supported | Escaped quote |
 | Double quote | `0'\"` | 34 | ✅ Supported | Escaped quote |
 | Empty | `0''` | N/A | ❌ Rejected | Syntax error as per ISO |
+
+**Validation rules**: Escapes must consume the entire literal (e.g., `0'\na'` raises a syntax error), and `\c` is rejected in character code notation even though it is permitted in quoted atoms/strings.
 
 **Difference from Scryer-Prolog**: Vibe does not require a trailing backslash for hex/octal escapes.
 
@@ -106,7 +109,7 @@ Vibe-Prolog supports all ISO/IEC 13211-1 escape sequences:
 | `\\` | Backslash | `'\\'` | ✅ Supported |
 | `\a` | Alert/bell (7) | `'\a'` | ✅ Supported |
 | `\b` | Backspace (8) | `'\b'` | ✅ Supported |
-| `\c` | No output (used in writeq) | `'\c'` | ✅ Supported |
+| `\c` | No output (used in writeq) | `'\c'` | ✅ Supported in quoted atoms/strings; rejected in `0'...` |
 | `\d` | Delete (127) | `'\d'` | ✅ Supported |
 | `\e` | Escape (27) | `'\e'` | ✅ Supported |
 | `\f` | Form feed (12) | `'\f'` | ✅ Supported |
@@ -116,8 +119,10 @@ Vibe-Prolog supports all ISO/IEC 13211-1 escape sequences:
 | `\t` | Tab (9) | `'\t'` | ✅ Supported |
 | `\v` | Vertical tab (11) | `'\v'` | ✅ Supported |
 | `\0...\777` | Octal character code | `'\141'` (a) | ✅ Supported |
-| `\xHH...` | Hex character code | `'\x41'` (A) | ✅ Supported |
-| `\uXXXX` | Unicode character code | `'\u0041'` (A) | ✅ Supported |
+| `\xHH...` | Hex character code | `'\x41'` (A) | ✅ Supported; accepts optional trailing `\` |
+| `\uXXXX` | Unicode character code | `'\u0041'` (A) | ✅ Supported; exactly four hex digits |
+
+**Line continuations**: A backslash followed by a newline is removed (along with subsequent indentation whitespace), allowing long quoted atoms/strings to span lines without embedding a newline.
 
 ### Special Atom Cases
 

--- a/tests/test_parser_strings.py
+++ b/tests/test_parser_strings.py
@@ -314,7 +314,7 @@ class TestRealWorldExamples:
     def test_file_paths(self):
         """Test file path strings with backslashes."""
         parser = PrologParser()
-        test_code = r"path('C:\Users\Name\file.txt')."
+        test_code = r"path('C:\\Users\\Name\\file.txt')."
         result = parser.parse(test_code)
         # Note: doubled backslashes in the string
         assert result[0].head.args[0].name == r"C:\Users\Name\file.txt"


### PR DESCRIPTION
Closes #325

- Add tests/test_escapes.py with extensive ISO Prolog escape sequence coverage for strings, quoted atoms, and character codes.
- Extend the parser (vibeprolog/parser.py) to support robust ISO escape handling:
  - Implement _parse_escape_sequence and _unescape_string for correct backslash processing.
  - Support single-character escapes (a, b, c, d, e, f, n, r, s, t, v, ', ", \, etc.).
  - Support octal escapes (\0…\377), hex escapes (\xHH...), and Unicode escapes (\uXXXX).
  - Proper handling of \c (no output) and proper error reporting for invalid escapes.
  - Update handling to preserve correct results in strings and quoted atoms.
- Adjust CHAR_CODE pattern to accommodate broader escape and hex/unicode forms.
- Update ISO conformity testing documentation (docs/CONFORMITY_TESTING.md) to reflect updated results and metadata.